### PR TITLE
compass és bundler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -288,4 +288,61 @@ module.exports = function( grunt ) {
 
   });
 
+  // override compass task to use bundler
+  // @todo this should be removed later
+  grunt.renameTask('compass', 'original-compass');
+
+  (function (grunt) {
+    'use strict';
+
+    var _ = grunt.util._;
+
+    function optsToArgs( opts ) {
+      var args = [];
+
+      Object.keys( opts ).forEach(function( el ) {
+        var val = opts[ el ];
+
+        el = el.replace( /_/g, '-' );
+
+        if ( val === true ) {
+          args.push( '--' + el );
+        }
+
+        if ( _.isString( val ) ) {
+          args.push( '--' + el, val );
+        }
+
+        if( _.isArray( val ) ) {
+          val.forEach(function( subval ) {
+            args.push( '--' + el, subval );
+          });
+        }
+      });
+
+      return args;
+    }
+
+    grunt.registerMultiTask( 'compass', 'Compass task', function() {
+      var cb = this.async();
+      var args = optsToArgs( this.options() );
+
+      var compass = grunt.util.spawn({
+        cmd: './bundle',
+        args: ['exec', 'compass', 'compile'].concat( args )
+      }, function( err, result, code ) {
+        if ( /not found/.test( err ) ) {
+          grunt.fail.fatal('You need to have Compass installed.');
+        }
+        // Since `compass compile` exits with 1 when it has nothing to compile,
+        // we do a little workaround by checking stdout which is then empty
+        // https://github.com/chriseppstein/compass/issues/993
+        cb( code === 0 || !result.stdout );
+      });
+
+      compass.stdout.pipe( process.stdout );
+      compass.stderr.pipe( process.stderr );
+    });
+  })(grunt);
+
 };


### PR DESCRIPTION
Nekem alapból kiírt egy ilyen hibát:

```
❯❯❯ yeoman server                                                                                                                                    
Running "server" task

Starting static web server on port 3501
  - /home/egabor/dev/sites/mentha-sitebuild/app
I'll also watch your files for changes, recompile if neccessary and live reload the page.
Hit Ctrl+C to quit.

Running "original-clean" task

Running "template:html" (template) task
HTML written to 'temp/index.html'

Running "coffee:compile" (coffee) task
File temp/scripts/frontend/main.js created.

Running "compass:compile" (compass) task
Gem::LoadError on line ["31"] of /home/egabor/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/bundler-1.2.3/lib/bundler/runtime.rb: You have already activated oily_png 1.0.3, but your Gemfile requires oily_png 1.0.2. Using bundle exec may solve this.
Run with --trace to see the full backtrace

Running "open-browser" task

Running "watch" task
Waiting...Error: /styles/frontend/main.css Not Found
    at Object.exports.error (/usr/lib/node_modules/yeoman/node_modules/connect/lib/utils.js:43:13)
    at Object.errorHandler [as handle] (/usr/lib/node_modules/yeoman/tasks/server.js:388:31)
    at next (/usr/lib/node_modules/yeoman/node_modules/connect/lib/proto.js:190:15)
    at exports.send (/usr/lib/node_modules/yeoman/node_modules/connect/lib/middleware/static.js:157:11)
    at Object.oncomplete (fs.js:297:15)
```

Ez azért van mert rosszul futtatja a compasst. Így átírva a taskot viszont már működik:

``` js
  grunt.registerMultiTask( 'compass', 'Compass task', function() {
    var cb = this.async();
    var args = optsToArgs( this.options() );

    var compass = grunt.util.spawn({
      cmd: './bundle',
      args: ['exec', 'compass', 'compile'].concat( args )
    }, function( err, result, code ) {
      if ( /not found/.test( err ) ) {
        grunt.fail.fatal('You need to have Compass installed.');
      }
      // Since `compass compile` exits with 1 when it has nothing to compile,
      // we do a little workaround by checking stdout which is then empty
      // https://github.com/chriseppstein/compass/issues/993
      cb( code === 0 || !result.stdout );
    });

    compass.stdout.pipe( process.stdout );
    compass.stderr.pipe( process.stderr );
  });
```

Van valami mód arra, hogy egy yeomanes grunt taskot helyileg felülírjunk?
